### PR TITLE
Bug #32: Update Docker compose for Api project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: nx-base
-    command: yarn nx serve express-app --host=0.0.0.0
+    command: yarn nx serve api --host=0.0.0.0
     ports:
       - 3333:3333
     environment:
@@ -32,7 +32,7 @@ services:
     extends:
       file: docker-compose.base.yml
       service: nx-base
-    command: ash ./apps/express-app/db/run_migrations.sh
+    command: ash ./apps/api/db/run_migrations.sh
     environment:
       - DB_CONNECTION_STRING=postgresql://postgres:postgres@db:5432/ukol
     depends_on:


### PR DESCRIPTION
Closes #32 

I forgot to update the `docker-compose` run commands for the now-`api` project after it's rename in #31 . Fixing that now.