### PR TITLE
Pass PORT from Terraform into `server` project runtime

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -34,6 +34,8 @@ ENV NODE_ENV production
 # react app files to serve via `express.static`.
 ENV REACT_APP_PATH ./web
 
+ENV PORT ${PORT}
+
 COPY --from=build /build/dist/apps/web ./web
 COPY --from=build /build/dist/apps/server .
 

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -155,8 +155,12 @@ resource "aws_ecs_task_definition" "web" {
           value = "http://${aws_lb.api.dns_name}:3333/graphql"
         },
         {
-          name = "API"
+          name = "API",
           value = "http://${aws_lb.api.dns_name}:3333/api"
+        },
+        {
+          name = "PORT",
+          value = local.web.port
         }
       ]
     }


### PR DESCRIPTION
fixes #53 

## Summary

This change ensures the current Terraform deployment scripts pass the correct `PORT` into the `server`/`web` Express app, and so therefore the app will respond to infrastructure health checks on the expected port.