### PR TITLE
Fix `PORT` datatype in terraform scripts for `web` project

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -160,7 +160,7 @@ resource "aws_ecs_task_definition" "web" {
         },
         {
           name = "PORT",
-          value = local.web.port
+          value = "${tostring(local.web.port)}"
         }
       ]
     }


### PR DESCRIPTION
fixes #55 

## Summary

As the bug states, the `PORT` environment variable needs to be coerced to a `string` for the `jsonencode` parser to work correctly.

This was tested with a full `terraform plan/apply/destroy` cycle from local state.