### PR TITLE
Fix #57: Disable `refetchOnWindowFocus` for `/config` call from frontend

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -13,10 +13,12 @@ app.use(express.static(REACT_APP_PATH));
 app.use(cors())
 
 app.get('/health', (_, res) => {
+  res.set('Cache-Control', 'no-cache');
   res.status(200).json({ status: 'OK' });
 });
 
 app.get('/config', (_, res) => {
+  res.set('Cache-Control', `public, max-age=${60*15}`)
   res.status(200).json({
     API: process.env['API'],
     GQL: process.env['GQL']

--- a/apps/web/src/app/config.tsx
+++ b/apps/web/src/app/config.tsx
@@ -17,14 +17,13 @@ export const useConfig = () => useContext(ConfigContext);
 
 export const ConfigProvider: FC<PropsWithChildren<ConfigProviderProps>> = ({ children, ...props }) => {
 
-  const getConfig = async () => {
-    const response = await fetch(environment.config);
-    return await response.json();
-  }
-
   const { error, data, isFetching } = useQuery<Config>({
     queryKey: ['config'],
-    queryFn: getConfig
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const response = await fetch(environment.config);
+      return await response.json();
+    }
   });
 
   if (isFetching) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       args:
         BUILD_ENV: development
     ports:
-      - 8080:8080
+      - 8000:8000
       - 9229:9229
     environment:
       - GQL=http://localhost:3333/graphql


### PR DESCRIPTION
fixes #57 

## Summary

This change will disable the `refetchOnWindowFocus` param for calls from the `ConfigProvider` from the React frontend.

Per the [Tanstack documentation](https://tanstack.com/query/latest/docs/framework/react/guides/window-focus-refetching), the `refetchOnWindowFocus` is defaulted to `true`. This means that the flicker seen in #57 was the default behavior of this tool.

I disable the behavior for this call specifically, since I'm not certain I want to do so yet for the entire app (see docs). I would consider something more later if I need to more heavily adopt server-controlled network caching (e.g. frontend Query cache obeys `Cache-Control` headers, for instance).

## Testing

Tested on local, running all app independently with `yarn nx serve...`.